### PR TITLE
Fix NullPointerException when crafting workbench-related items

### DIFF
--- a/src/main/java/net/kyrptonaught/quickshulker/api/Util.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/api/Util.java
@@ -63,7 +63,7 @@ public class Util {
 
     public static boolean areItemsEqual(ItemStack stack1, ItemStack stack2) {
         QuickShulkerData qsdata = QuickOpenableRegistry.getQuickie(stack1.getItem());
-        return ItemStack.areItemsEqual(stack1, stack2) && ItemStack.areEqual(stack1, stack2) && stack1.getCount() == stack2.getCount() && (qsdata.ignoreSingleStackCheck || stack1.getCount() == 1);
+        return ItemStack.areItemsEqual(stack1, stack2) && ItemStack.areEqual(stack1, stack2) && stack1.getCount() == stack2.getCount() && (qsdata != null && qsdata.ignoreSingleStackCheck || stack1.getCount() == 1);
     }
 
     public static ScreenHandlerListener forceCloseScreenIfNotPresent(PlayerEntity player, int slotID, ItemStack stack) {


### PR DESCRIPTION
Fix for NullPointerException when crafting workbench-related items

Issue Description:
When using Quick Shulker mod to open shulker boxes and attempting to craft items containing workbenches (e.g., Crafting Tables), a NullPointerException occurs causing the server to crash.

Error Log:
java.lang.NullPointerException: Cannot read field "ignoreSingleStackCheck" because "qsdata" is null
at knot//net.kyrptonaught.quickshulker.api.Util.areItemsEqual(Util.java:66)

Root Cause:
In the areItemsEqual method, there is a direct access to qsdata.ignoreSingleStackCheck without checking if qsdata is null.

Fix:
Added a null check before accessing the ignoreSingleStackCheck field.