### PR TITLE
fix: Game crash while throw the shulker box on opening the screen

### DIFF
--- a/src/main/java/net/kyrptonaught/quickshulker/api/Util.java
+++ b/src/main/java/net/kyrptonaught/quickshulker/api/Util.java
@@ -63,6 +63,7 @@ public class Util {
 
     public static boolean areItemsEqual(ItemStack stack1, ItemStack stack2) {
         QuickShulkerData qsdata = QuickOpenableRegistry.getQuickie(stack1.getItem());
+        if (qsdata == null) return false;  // may null, if player throw the shulker box while opening the screen...
         return ItemStack.areItemsEqual(stack1, stack2) && ItemStack.areEqual(stack1, stack2) && stack1.getCount() == stack2.getCount() && (qsdata.ignoreSingleStackCheck || stack1.getCount() == 1);
     }
 


### PR DESCRIPTION
This is a hard bug to find, but it was dug up by the _tricky_ players in my server lol. The server will throw an NPE while a player try to throw the shulker box out at the opening the screen process. Here is the crash report:

```
Time: 2025-06-18 19:12:28
Description: Ticking entity

java.lang.NullPointerException: Cannot read field "ignoreSingleStackCheck" because "qsdata" is null
	at net.kyrptonaught.quickshulker.api.Util.areItemsEqual(Util.java:66)
	at net.kyrptonaught.quickshulker.api.Util$1.isValid(Util.java:82)
	at net.kyrptonaught.quickshulker.api.Util$1.onSlotUpdate(Util.java:73)
	at net.minecraft.screen.ScreenHandler.updateTrackedSlot(ScreenHandler.java:257)
	at net.minecraft.screen.ScreenHandler.sendContentUpdates(ScreenHandler.java:214)
	at net.minecraft.server.network.ServerPlayerEntity.tick(ServerPlayerEntity.java:673)
	at net.minecraft.server.world.ServerWorld.tickEntity(ServerWorld.java:768)
	at net.minecraft.world.World.tickEntity(World.java:510)
	at net.minecraft.server.world.ServerWorld.method_31420(ServerWorld.java:403)
	at net.minecraft.world.EntityList.forEach(EntityList.java:54)
	at net.minecraft.server.world.ServerWorld.tick(ServerWorld.java:373)
	at net.minecraft.server.MinecraftServer.mixinextras$bridge$method_18765$326(MinecraftServer.java)
	at net.minecraft.server.MinecraftServer.wrapOperation$cgp000$carpet-tis-addition$yeetUpdateSuppressionCrash_implOnTickWorlds(MinecraftServer.java:8195)
	at net.minecraft.server.MinecraftServer.tickWorlds(MinecraftServer.java:1062)
	at net.minecraft.server.MinecraftServer.tick(MinecraftServer.java:946)
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:706)
	at net.minecraft.server.MinecraftServer.method_29739(MinecraftServer.java:290)
	at java.lang.Thread.run(Thread.java:1583)
```

So I make this fix.